### PR TITLE
Added minor value fen to declaration

### DIFF
--- a/src/cny.json5
+++ b/src/cny.json5
@@ -10,11 +10,21 @@
                 "name": "yuan",
                 "symbol": "¥"
             },
+            // There are acutally two minor values for 1 yuan
+            // 1 yuan = 10 jiao
+            // 1 yuan = 100 fen
+            // So, there must be some solution to reflect this
+            // As this means, values in yuan are normally written with 2 decimal digits, fen as the minor value should be preferred
             "minor": {
+                "name": "fēn",
+                "symbol": "分",
+                "majorValue": 0.01
+            },
+            "minor2": {
                 "name": "jiǎo",
                 "symbol": "角",
                 "majorValue": 0.1
-            }
+            },
         },
         "banknotes": {
             "frequent": [
@@ -26,6 +36,9 @@
                 "¥100"
             ],
             "rare": [
+                "分1",
+                "分2",
+                "分5",
                 "角1",
                 "角2",
                 "角5",
@@ -34,6 +47,9 @@
         },
         "coins": {
             "frequent": [
+                "分1",
+                "分2",
+                "分5",
                 "角1",
                 "角5",
                 "¥1"


### PR DESCRIPTION
The chinese renmimbi (yuan) has two minor values. The hundreds minor value fen was not represented in the api, yet.